### PR TITLE
Added power_cycle_nodes script

### DIFF
--- a/scripts/power_cycle_nodes
+++ b/scripts/power_cycle_nodes
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+# Copyright 2014 Massachusetts Open Cloud Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS
+# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""This is a simple script that can be used to power cycle all nodes registered in the HaaS."""
+
+from haas import api
+
+if len(sys.argv) < 2:
+    print('Usage:  power_cycle_nodes <project>')
+else:
+    project = sys.argv[1]
+    nodes = json.loads(api.list_free_nodes(project))
+    for node in nodes:
+        api.node_power_cycle(node)

--- a/scripts/power_cycle_nodes
+++ b/scripts/power_cycle_nodes
@@ -14,14 +14,23 @@
 # express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-"""This is a simple script that can be used to power cycle all nodes registered in the HaaS."""
+"""This is a simple script that can be used to power cycle all nodes
+   belonging to a HaaS project."""
 
-from haas import api
+from haas import cli
+from haas import config
+from cStringIO import StringIO
+import sys
+import json
 
+config.load()
 if len(sys.argv) < 2:
     print('Usage:  power_cycle_nodes <project>')
 else:
     project = sys.argv[1]
-    nodes = json.loads(api.list_free_nodes(project))
+    sys.stdout = mystdout = StringIO()      # redirect cli ouput to buffer
+    cli.list_project_nodes(project)
+    sys.stdout = sys.__stdout__             # reset sdout
+    nodes = json.loads(mystdout.getvalue()) # read buffer
     for node in nodes:
-        api.node_power_cycle(node)
+        cli.node_power_cycle(node)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(name='haas',
       version='1.0',
       url='https://github.com/CCI-MOC/haas',
       packages=find_packages(),
-      scripts=['scripts/haas', 'scripts/create_bridges'],
+      scripts=['scripts/haas', 'scripts/create_bridges', 'scripts/power_cycle_nodes'],
       install_requires=requirements,
       )


### PR DESCRIPTION
Simple script that takes a project name and calls the CLI command to power cycle all of its nodes.

This PR was inteded to address the Trello backlog task ```trivial head node script to talk to HaaS API, power cycle machines...```, although now that I read it again I'm not sure that I actually addressed it.  Were we looking for something to actually run *on* the headnode?

I had to do some funky stuff to use the CLI module to do this.  Although, I don't know if there is a better option.