### PR TITLE
Add a list_projects command to the API/CLI

### DIFF
--- a/haas/api.py
+++ b/haas/api.py
@@ -661,6 +661,22 @@ def port_detach_nic(port):
     db.commit()
 
 
+@rest_call('GET', '/projects')
+def list_projects():
+    """List all projects and nodes that belong to them.
+
+    Returns a JSON array of objects representing a list of projects.
+
+    Example:  '[{"nodes": ["node1", "node2"], "name": "project1"},
+                {"nodes": ["node3", "node4"], "name": "project2"}]'
+    """
+    db = model.Session()
+    projects = db.query(model.Project).all()
+    projects = [{'name': p.label, 'nodes': [n.label for n in p.nodes]}
+                for p in projects]
+    return json.dumps(projects)
+
+
 @rest_call('GET', '/free_nodes')
 def list_free_nodes():
     """List all nodes not in any project.

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -313,6 +313,12 @@ def port_detach_nic(port):
     do_post(url)
 
 @cmd
+def list_projects():
+    """List all projects and their nodes"""
+    url = object_url('projects')
+    do_get(url)
+
+@cmd
 def list_free_nodes():
     """List all free nodes"""
     url = object_url('free_nodes')


### PR DESCRIPTION
In response to issue #355, add a new API call to list all projects
and the nodes connected to them.

@henn, is this what you were looking for?