### PR TITLE
Remove unused import.

### DIFF
--- a/haas/model.py
+++ b/haas/model.py
@@ -18,7 +18,6 @@ from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.orm import relationship, sessionmaker,backref
 from passlib.hash import sha512_crypt
 from subprocess import call, check_call, Popen, PIPE
-import subprocess
 from haas.config import cfg
 from haas.dev_support import no_dry_run
 import importlib


### PR DESCRIPTION
We're using some things from subprocess in haas.model, but we import
those individually.