### PR TITLE
Get haas.model working with things besides sqlite 

### DIFF
--- a/haas.cfg.dev-example
+++ b/haas.cfg.dev-example
@@ -57,8 +57,8 @@ endpoint = http://127.0.0.1:5000
 
 [database]
 # A SQLAlchemy database URI, specifying the database for the server to
-# connect to. At present, only sqlite is supported. The example below is a
-# relative path, which looks for the database in the current directory.
+# connect to. At present, sqlite and mysql are supported. The example
+# below uses sqlite, and looks for the database in the current directory.
 uri = sqlite:///haas.db
 
 [driver simple_vlan]

--- a/haas.cfg.example
+++ b/haas.cfg.example
@@ -47,7 +47,7 @@ libvirt_endpoint = qemu:///system
 # The http endpoint that the command line tool should connect to. The server
 # doesn't use this; it must be configured separately. To double check that you
 # have the right value, make sure the API server is running, and execute::
-# 
+#
 #   haas list_free_nodes
 #
 # from within the directory containing haas.cfg.
@@ -55,12 +55,18 @@ endpoint = http://127.0.0.1
 
 [database]
 # A SQLAlchemy database URI, specifying the database for the server to
-# connect to. At present, only sqlite is supported. Both the API server
-# and ``haas serve_networks`` need write access to the database.
+# connect to. Both MySQL and SQLite are supported. If using mysql, this should
+# look something like:
+uri = mysql://user:password@localhost/haas
+# If using SQLite, the following value may be appropriate:
 #
-# The suggested value below assumes both will run as a system user
+# uri = sqlite:////var/lib/haas/haas.db
+#
+# The suggested value above assumes both will run as a system user
 # whose home directory is ``/var/lib/haas``.
-uri = sqlite:////var/lib/haas/haas.db
+#
+# Both the API server  and ``haas serve_networks`` need write access to
+# the database.
 
 [driver simple_vlan]
 # Driver specific settings for the ``simple_vlan`` driver.

--- a/haas/model.py
+++ b/haas/model.py
@@ -243,14 +243,14 @@ class Network(Model):
     # The project to which the network belongs, or None if the network was
     # created by the administrator.  This field determines who can delete a
     # network.
-    creator_id = Column(String,ForeignKey('project.id'))
+    creator_id = Column(Integer, ForeignKey('project.id'))
     creator    = relationship("Project",
                               backref=backref('networks_created'),
                               foreign_keys=[creator_id])
     # The project that has access to the network, or None if the network is
     # public.  This field determines who can connect a node or headnode to a
     # network.
-    access_id = Column(String, ForeignKey('project.id'))
+    access_id = Column(Integer, ForeignKey('project.id'))
     access    = relationship("Project",
                              backref=backref('networks_access'),
                              foreign_keys=[access_id])
@@ -330,7 +330,7 @@ class Headnode(Model):
     """A virtual machine used to administer a project."""
 
     # The project to which this Headnode belongs:
-    project_id = Column(String, ForeignKey('project.id'), nullable=False)
+    project_id = Column(Integer, ForeignKey('project.id'), nullable=False)
     project = relationship("Project", backref=backref('headnode', uselist=True))
 
     # True iff there are unapplied changes to the Headnode:

--- a/haas/test_common.py
+++ b/haas/test_common.py
@@ -40,9 +40,15 @@ def newDB():
     init_db(create=True,uri="sqlite:///:memory:")
     return Session()
 
+
 def releaseDB(db):
-    """Do we need to do anything here to release resources?"""
-    pass
+    """Clean out the database, so it's empty for the next test."""
+    db.commit()
+    db = Session()
+    for cls in Model.__subclasses__():
+        db.query(cls).delete()
+    db.query(NetworkingAction).delete()
+    db.commit()
 
 
 def clear_configuration(f):


### PR DESCRIPTION
This now at least populates the db with MySQL. I'm putting the do not merge label on this, because I want to test it more thoroughly against mysql first.

The main thing that was required was explicit length fields for string/varchar columns. Perhaps troublingly, the default behavior seems to be to silently truncate any values that are too big to fit. We should probably check this ourselves, which this doesn't do currently