### PR TITLE
flesh out API documentation

### DIFF
--- a/docs/apidesc.md
+++ b/docs/apidesc.md
@@ -28,7 +28,7 @@ Additionally, we provide one built-in authorization model, that adds another kin
 ## API design philosophy
 
 We provide the most basic API that we can, and attempt to impose no structure
-that is not required for authorization purposes.  
+that is not required for authorization purposes.
 
 - A 'project' is merely an authorization domain.  It is reasonable to have
   logically independent groupings of resources within one project, but the
@@ -57,26 +57,26 @@ one exception is NICs, where the label is unique only on a per-node basis.
 
 
 ## User operations:
- 
-    # Basic node allocation and network isolation 
+
+    # Basic node allocation and network isolation
 
     network_create              <network_label> <proj_creator> <proj_access> <id>
     network_delete              <network_label>
 
     project_connect_node        <project_label> <node_label>
     project_detach_node         <project_label> <node_label>
- 
+
     node_connect_network        <node_label> <nic_label> <network_label>
     node_detach_network         <node_label> <nic_label>
 
-    # Headnode operations 
+    # Headnode operations
 
     headnode_create             <hn_label> <project_label>
     headnode_delete             <hn_label>
 
     headnode_start              <hn_label>
     headnode_stop               <hn_label>
- 
+
     headnode_create_hnic        <hn_label> <hnic_label>
     headnode_delete_hnic        <hn_label> <hnic_label>
 
@@ -87,7 +87,7 @@ one exception is NICs, where the label is unique only on a per-node basis.
 
     node_power_cycle           <node_label>
 
-    start_console              <node_label>    
+    start_console              <node_label>
     show_console               <node_label>
     stop_console               <node_label>
 
@@ -105,7 +105,7 @@ one exception is NICs, where the label is unique only on a per-node basis.
 ## Authorization-related operations:
 
     # Always useful
- 
+
     project_create              <project_label>
     project_delete              <project_label>
 

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -601,10 +601,6 @@ Possible Errors:
     [POST] /port/<port_no>/connect_nic
     [POST] /port/<port_no>/detach_nic
 
-    import_vlan <network_label> <vlan_label>
-    block_user <user_label>
-    unblock_user <user_label>
-
     list_project_headnodes <project> -> [
             "<headnode1_name>",
             "<headnode2_name>",

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -34,24 +34,53 @@ Possible errors:
 
 ## Networks
 
+### network_create
+
+`PUT /network/<network>`
+
+Request Body:
+
+    {
+        "creator": <creator>,
+        "access": <access>,
+        "net_id": <net_id>
+    }
+
+Create a network. For the semantics of each of the fields, see
+`docs/network.md`.
+
+Possible errors:
+
+* 409, if a network by that name already exists.
+* See also bug #461
+
 ### show_network
 
 `GET /network/<network>`
 
 View detailed information about `<network>`.
 
-The result contains the following information:
+The result must contain the following fields:
 
-* The name of the network
-* A description of legal channel identifiers for this network. This is a list
-  of channel identifiers, with possible wildcards. The format of these is
-  driver specific, see below.
+* "name", the name of the network
+* "channels", description of legal channel identifiers for this network.
+  This is a list of channel identifiers, with possible wildcards. The
+  format of these is driver specific, see below.
+* "creator", the name of the project which created the network, or
+  "admin", if it was created by an administrator.
+
+The result may also contain the following fields:
+
+* "access" -- if this is present, it is the name of the project which
+  has access to the network. Otherwise, the network is public.
 
 Response body (on success):
 
     {
-        "name": <network>
-        "channels": <chanel-id-list>
+        "name": <network>,
+        "channels": <chanel-id-list>,
+        "creator": <project or "admin">,
+        "access": <project with access to the network> (Optional)
     }
 
 Possible errors:
@@ -131,15 +160,37 @@ Possible Errors:
   * There is already a pending network operation on `<nic>`.
   * `<network>` is not attached to `<nic>`.
 
+## Projects
+
+### project_create
+
+`PUT /project/<project>`
+
+Create a project named `<project>`
+
+Possible Errors:
+
+* 409, if the project already exists
+
+### project_delete
+
+`DELETE /project/<project>`
+
+Delete the project named `<project>`
+
+Possible Errors:
+
+* 409, if:
+  * The project does not exist
+  * The project still has resources allocated to it:
+    * nodes
+    * networks
+    * headnodes
+
 # TODO
 
 These api calls still need to be documented in detail, but the below
 provides a summary:
-
-    project_create <project_label>
-    project_delete <project_label>
-    [PUT]    /project/<project_label>
-    [DELETE] /project/<project_label>
 
     network_create <network_label> <proj_creator> <proj_access> <net_id>
     network_delete <network_label>

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -13,10 +13,15 @@ Each possible API call has an entry below containing:
   not return any data, in which case this is omitted.
 * A list of possible errors.
 
-In addition to the error codes listed for each API call, HaaS may return
-a `400 Bad Request` if something is wrong with the request (e.g.
-malformed request body), or `401 Unauthorized` if the user does not have
-permission to execute the supplied request.
+In addition to the error codes listed for each API call, HaaS may 
+return:
+
+* 400 if something is wrong with the request (e.g. malformed request 
+  body)
+* 401 if the user does not have permission to execute the supplied 
+  request.
+* 404 if the api call references an object that does not exist 
+  (obviously, this is acceptable for calls that create the resource)
 
 Below is an example.
 
@@ -83,10 +88,6 @@ Possible errors:
 
 Delete the user whose username is `<username>`
 
-Possible errors:
-
-* 404, if the user does not exist
-
 ## Networks
 
 ### network_create
@@ -119,7 +120,6 @@ Finally, there may not be any pending actions involving the network.
 
 Possible Errors:
 
-* 404, if the network does not exist
 * 409 if:
     * The network is connected to a node or headnode.
     * There are pending actions involving the network.
@@ -152,10 +152,6 @@ Response body (on success):
         "creator": <project or "admin">,
         "access": <project with access to the network> (Optional)
     }
-
-Possible errors:
-
-* 404, if the network does not exist.
 
 #### Channel Formats
 
@@ -248,10 +244,6 @@ Possible errors:
 
 Delete the node named `<node>` from the database.
 
-Possible errors:
-
-* 404 if the node does not exist
-
 ### node_register_nic
 
 `PUT /node/<node>/nic/<nic>`
@@ -268,7 +260,6 @@ for users trying to configure their nodes.
 
 Possible errors:
 
-* 404 if `<node>` does not exist
 * 409 if `<node>` already has a nic named `<nic>`
 
 ### node_delete_nic
@@ -277,20 +268,12 @@ Possible errors:
 
 Delete the nic named `<nic>` and belonging to `<node>`.
 
-Possible errors:
-
-* 404 if `<nic>` or `<node>` does not exist.
-
 ### node_power_cycle
 
 `POST /node/<node>/power_cycle`
 
 Power cycle the node named `<node>`, and set it's next boot device to
 PXE.
-
-Possible errors:
-
-* 404, if `<node>` does not exist.
 
 ### list_free_nodes
 
@@ -320,10 +303,6 @@ Response body:
         ...
     ]
 
-Possible errors:
-
-* 404 if `<project>` does not exist
-
 ### show_node
 
 `GET /node/<node>`
@@ -346,10 +325,6 @@ Response body:
         "free": true,
         "nics": ["ipmi", "pxe", "external",...]
     }
-
-Possible errors:
-
-* 404, if the node does not exist
 
 ## Projects
 
@@ -408,10 +383,6 @@ Return `<node>` to the free pool. `<node>` must belong to the project
 `<project>`. It must not be attached to any networks, or have any
 pending network actions.
 
-Possible errors:
-
-* 404, if `<node>` or `<project>` does not exist, or `<node>` does not
-  belong to `<project>`.
 * 409, if the node is attached to any networks, or has pending network
   actions.
 
@@ -448,17 +419,12 @@ Create a headnode owned by project `<project>`, cloned from base image
 Possible errors:
 
 * 409, if a headnode named `<headnode>` already exists
-* 404, if the project does not exist.
 
 ### headnode_delete
 
 `DELETE /headnode/<headnode>`
 
 Delete the headnode named `<headnode>`.
-
-Possible errors:
-
-* 404, if `<headnode>` does not exist.
 
 ### headnode_start
 
@@ -468,20 +434,12 @@ Start (power on) the headnode. Note that once a headnode has been
 started, it cannot be modified (adding/removing hnics, changing
 networks), only deleted --- even if it is stopped.
 
-Possible errors:
-
-* 404, if `<headnode>` does not exist.
-
 ### headnode_stop
 
 `POST /headnode/<headnode>/stop`
 
 Stop (power off) the headnode. This does a force power off; the VM is
 not given the opportunity to shut down cleanly.
-
-Possible errors:
-
-* 404, if `<headnode>` does not exist.
 
 ### headnode_create_hnic
 
@@ -490,9 +448,6 @@ Possible errors:
 Create an hnic named `<hnic>` belonging to `<headnode>`. The headnode
 must not have previously been started.
 
-Possible errors:
-
-* 404, if the headnode does not exist.
 * 409, if:
   * The headnode already has an hnic by the given name.
   * The headnode has already been started.
@@ -504,9 +459,6 @@ Possible errors:
 Delete the hnic named `<hnic>` and belonging to `<headnode>`. The
 headnode must not have previously been started.
 
-Possible errors:
-
-* 404, if the headnode or hnic does not exist.
 * 409, if the headnode has already been started.
 
 ### headnode_connect_network
@@ -542,7 +494,6 @@ important.
 
 Possible errors:
 
-* 404, if the headnode or hnic does not exist.
 * 409, if the headnode has already been started.
 
 ### headnode_detach_network
@@ -552,7 +503,6 @@ Possible errors:
 Detach the network attached to `<hnic>`.  The headnode must not have
 previously been started.
 
-* 404, if the headnode or hnic does not exist.
 * 409, if the headnode has already been started.
 
 ### list_project_headnodes
@@ -568,11 +518,6 @@ Response body:
         "<headnode2_name>",
         ...
     ]
-
-Possible errors:
-
-* 404, if the project does not exist
-
 
 ### show_headnode
 
@@ -596,10 +541,6 @@ Response body:
         "nics": [<nic1>, <nic2>, ...],
         "vncport": <port number>
     }
-
-Possible errors:
-
-* 404, if the headnode does not exist
 
 ## Switches
 
@@ -636,7 +577,6 @@ deleted.
 
 Possible Errors:
 
-* 404, if the named switch does not exist
 * 409, if not all of the switch's ports have been deleted.
 
 ### switch_register_port
@@ -651,7 +591,6 @@ information.
 
 Possible Errors:
 
-* 404, if the named switch does not exist
 * 409, if the port already exists
 
 ### switch_delete_port
@@ -664,7 +603,6 @@ Prior to deleting a port, any nic attached to it must be removed.
 
 Possible Errors:
 
-* 404, if the port or switch does not exist
 * 409, if there is a nic attached to the port.
 
 ### port_connect_nic
@@ -682,7 +620,6 @@ Connect a port a node's nic.
 
 Possible errors:
 
-* 404, if the node, nic, switch, or port does not exist.
 * 409, if the nic or port is already attached to something.
 
 ### port_detach_nic
@@ -693,7 +630,5 @@ Detach the nic attached to `<port>`.
 
 Possible errors:
 
-* 404 if:
-  * the switch or port does not exist
-  * the port is not attached to a nic
+* 404, if the port is not attached to a nic
 * 409, if the port is attached to a node which is not free.

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -2,7 +2,7 @@ This file documents the HaaS REST API in detail.
 
 # How to read
 
-Each possible API call had a entry below containing:
+Each possible API call has an entry below containing:
 
 * an HTTP method and URL path, including possible `<parameters>` in the
   path to be treated as arguments.

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -324,6 +324,33 @@ Possible errors:
 
 * 404 if `<project>` does not exist
 
+### show_node
+
+`GET /node/<node>`
+
+Show detailed information about a node. The response includes the
+following fields:
+
+* "name", the name/label of the node.
+* "free", indicates whether the node is free or has been allocated
+    to a project.
+* "nics", a list of nics, each represted by a JSON object having
+    at least the following fields:
+        * "label", the nic's label.
+        * "macaddr", the nic's mac address.
+
+Response body:
+
+    {
+        "name": "box02",
+        "free": true,
+        "nics": ["ipmi", "pxe", "external",...]
+    }
+
+Possible errors:
+
+* 404, if the node does not exist
+
 ## Projects
 
 ### project_create
@@ -528,6 +555,52 @@ previously been started.
 * 404, if the headnode or hnic does not exist.
 * 409, if the headnode has already been started.
 
+### list_project_headnodes
+
+`GET /project/<project>/headnodes`
+
+Get a list of names of headnodes belonging to `<project>`.
+
+Response body:
+
+    [
+        "<headnode1_name>",
+        "<headnode2_name>",
+        ...
+    ]
+
+Possible errors:
+
+* 404, if the project does not exist
+
+
+### show_headnode
+
+`GET /headnode/<headnode>`
+
+Get information about a headnode. Includes the following fields:
+
+* "name", the name/label of the headnode (string).
+* "project", the project to which the headnode belongs.
+* "hnics", a JSON array of hnic names that are attached to this
+    headnode.
+* "vncport", the vnc port that the headnode VM is listening on; this
+    value can be `null` if the VM is powered off or has not been
+    created yet.
+
+Response body:
+
+    {
+        "name": <headnode>,
+        "project": <projectname>,
+        "nics": [<nic1>, <nic2>, ...],
+        "vncport": <port number>
+    }
+
+Possible errors:
+
+* 404, if the headnode does not exist
+
 ## Switches
 
 ### switch_register
@@ -594,32 +667,33 @@ Possible Errors:
 * 404, if the port or switch does not exist
 * 409, if there is a nic attached to the port.
 
----
+### port_connect_nic
 
-    port_connect_nic <port_no> <node_label> <nic_label>
-    port_detach_nic  <port_no>
-    [POST] /port/<port_no>/connect_nic
-    [POST] /port/<port_no>/detach_nic
+`POST /switch/<switch>/port/<port>/connect_nic`
 
-    list_project_headnodes <project> -> [
-            "<headnode1_name>",
-            "<headnode2_name>",
-            ...
-        ]
-    [GET] /project/<project>/headnodes
+Request body:
 
-    show_node <node> ->
-        {
-            "name": "box02",
-            "free": true,
-            "nics": ["ipmi", "pxe", "external",...]
-        }
-    [GET] /node/<node>
+    {
+        "node": <node>,
+        "nic": <nic>
+    }
 
-    show_headnode <headnode> ->
-        {
-            "name": "hn04",
-            "project": "projectname",
-            "nics": ["ipmi", "pxe", "public", ...]
-        }
-    [GET] /headnode/<headnode>
+Connect a port a node's nic.
+
+Possible errors:
+
+* 404, if the node, nic, switch, or port does not exist.
+* 409, if the nic or port is already attached to something.
+
+### port_detach_nic
+
+`POST /switch/<switch>/port/<port>/detach_nic`
+
+Detach the nic attached to `<port>`.
+
+Possible errors:
+
+* 404 if:
+  * the switch or port does not exist
+  * the port is not attached to a nic
+* 409, if the port is attached to a node which is not free.

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -1,8 +1,63 @@
+This file documents the HaaS REST API in detail.
+
+# How to read
+
+Each possible API call had a entry below containing:
+
+* an HTTP method and URL path, including possible `<parameters>` in the
+  path to be treated as arguments.
+* Optionally, a summary of the request body (which will always be a JSON
+  object).
+* A human readable description of the semantics of the call
+* A summary of the response body for a successful request. Many calls do
+  not return any data, in which case this is omitted.
+* A list of possible errors.
+
+In addition to the error codes listed for each API call, HaaS may return
+a `400 Bad Request` if something is wrong with the request (e.g.
+malformed request body), or `401 Unauthorized` if the user does not have
+permission to execute the supplied request.
+
+Below is an example.
+
+## my_api_call
+
+`POST /url/path/to/<thing>`
+
+Request Body:
+
+    {
+        "some_field": "a value",
+        "this-is-an-example": true,
+        "some-optional-field": { (Optional)
+            "more-fields": 12352356,
+            ...
+        }
+    }
+
+Attempt to do something mysterious to `<thing>` which must be a coffee
+pot, and must not be in use by other users. If successful, the response
+will include some cryptic information.
+
+Response Body (on success):
+
+    {
+        "some-info": "Hello, World!",
+        "numbers": [1,2,3]
+    }
+
+Possible errors:
+
+* 418, if `<thing>` is a teapot.
+* 409, if:
+  * `<thing>` does not exist
+  * `<thing>` is busy
+
 
 * `{"foo": <bar>, "baz": <quux>}` denotes a JSON object (in the body of
   the request).
 
-# Full Api spec:
+# Full API Specification
 
 ## Users
 

--- a/haas/api.py
+++ b/haas/api.py
@@ -602,15 +602,8 @@ def network_delete(network):
 def show_network(network):
     """Show details of a network.
 
-    Returns a JSON object representing a network.
-    The object will have at least the following fields:
-        * "name", the name/label of the network (string).
-        * "creator", the name of the project which created the network, or
-          "admin", if it was created by an administrator.
-        * "channels", a list of channels to which the network may be attached.
-    It may also have the fields:
-        * "access" -- if this is present, it is the name of the project which
-          has access to the network. Otherwise, the network is public.
+    Returns a JSON object representing a network. See `docs/rest_api.md`
+    for a full description of the output.
     """
     db = model.Session()
     allocator = get_network_allocator()

--- a/haas/api.py
+++ b/haas/api.py
@@ -240,9 +240,9 @@ def node_register_nic(node, nic, macaddr):
 
 @rest_call('DELETE', '/node/<node>/nic/<nic>')
 def node_delete_nic(node, nic):
-    """Delete nic with given name.
+    """Delete nic with given name from it's node.
 
-    If the nic does not exist, a NotFoundError will be raised.
+    If the node or nic does not exist, a NotFoundError will be raised.
     """
     db = model.Session()
     nic = _must_find_n(db, _must_find(db, model.Node, node), model.Nic, nic)
@@ -581,6 +581,9 @@ def network_delete(network):
     """Delete network.
 
     If the network does not exist, a NotFoundError will be raised.
+
+    If the network is connected to nodes or headnodes, or there are pending
+    network actions involving it, a BlockedError will be raised.
     """
     db = model.Session()
     network = _must_find(db, model.Network, network)

--- a/haas/api.py
+++ b/haas/api.py
@@ -129,6 +129,9 @@ def project_detach_node(project, node):
     """Remove a node from a project.
 
     If the node or project does not exist, a NotFoundError will be raised.
+
+    If the node has network attachments or pending network actions, a
+    BlockedError will be raised.
     """
     db = model.Session()
     project = _must_find(db, model.Project, project)
@@ -355,13 +358,13 @@ def node_detach_network(node, nic, network):
 def headnode_create(headnode, project, base_img):
     """Create headnode.
 
-    If a node with the same name already exists, a DuplicateError will be
+    If a headnode with the same name already exists, a DuplicateError will be
     raised.
-
-    If the project already has a headnode, a DuplicateError will be raised.
 
     If the project does not exist, a NotFoundError will be raised.
 
+    If the base image does not exist (not specified in haas.cfg) a
+    BadArgumentError will be raised.
     """
 
     valid_imgs = cfg.get('headnode', 'base_imgs')
@@ -434,6 +437,9 @@ def headnode_create_hnic(headnode, hnic):
 
     If there is already an hnic with that name, a DuplicateError will
     be raised.
+
+    If the headnode's VM has already created (headnode is not "dirty"), raises
+    an IllegalStateError
     """
     db = model.Session()
     headnode = _must_find(db, model.Headnode, headnode)
@@ -451,7 +457,10 @@ def headnode_create_hnic(headnode, hnic):
 def headnode_delete_hnic(headnode, hnic):
     """Delete hnic on a given headnode.
 
-    If the hnic does not exist, a NotFoundError will be raised.
+    If the headnode or hnic does not exist, a NotFoundError will be raised.
+
+    If the headnode's VM has already created (headnode is not "dirty"), raises
+    an IllegalStateError
     """
     db = model.Session()
     headnode = _must_find(db, model.Headnode, headnode)


### PR DESCRIPTION
Everything in rest_api.md is filled out now. There's still some more to do --- I'd like to get rid of the function names, and apidesc.md is still there and pretty much unchanged (i.e. very bitrotted), but I think this is a good self-contained change.

This builds on top of #455, so that should be merged first.