### PR TITLE
Dont call api twice

### DIFF
--- a/haas/rest.py
+++ b/haas/rest.py
@@ -228,7 +228,6 @@ def request_handler(request):
                 raise InternalServerError()
             request_data[k] = v
         logger.debug('Recieved api call %s(%s)', f.__name__, _format_arglist(**request_data))
-        response_body = f(**request_data)
         result = f(**request_data)
         if result is None:
             response_body, status = "", 200

--- a/haas/server.py
+++ b/haas/server.py
@@ -50,6 +50,6 @@ def api_server_init():
     this module in the correct order, as well as ``model.init_db``
     """
     register_drivers()
-    model.init_db()
     validate_state()
+    model.init_db()
     stop_orphan_consoles()

--- a/tests/unit/api.py
+++ b/tests/unit/api.py
@@ -318,7 +318,6 @@ class TestNodeRegisterDelete:
         with pytest.raises(api.NotFoundError):
             api.node_delete('node-99')
 
-    @database_only
     def test_node_delete_nic_exist(self, db):
         """node_delete should respond with an error if the node has nics."""
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')

--- a/tests/unit/cli.py
+++ b/tests/unit/cli.py
@@ -1,0 +1,70 @@
+import pytest
+import tempfile
+import os
+import signal
+from subprocess import check_call, Popen
+from time import sleep
+
+config = """
+[headnode]
+base_imgs = base-headnode, img1, img2, img3, img4
+[database]
+uri = sqlite:///haas.db
+[extensions]
+haas.ext.network_allocators.null =
+"""
+
+
+@pytest.fixture(autouse=True)
+def make_config(request):
+    tmpdir = tempfile.mkdtemp()
+    cwd = os.getcwd()
+    os.chdir(tmpdir)
+    with open('haas.cfg', 'w') as f:
+        f.write(config)
+
+    def cleanup():
+        os.remove('haas.cfg')
+        os.remove('haas.db')
+        os.chdir(cwd)
+        os.rmdir(tmpdir)
+
+    request.addfinalizer(cleanup)
+
+
+def test_init_db():
+    check_call(['haas', 'init_db'])
+
+
+def runs_for_seconds(cmd, seconds=1):
+    """Test if the command ``cmd`` runs for at least ``seconds`` seconds.
+
+    ``cmd`` is a list containing the name of a command and its arguments.
+
+    ``seconds`` is a number of seconds (by default 1).
+
+    ``run_for_seconds`` will execute ``cmd``, wait for ``seconds`` seconds,
+    send SIGTERM to the process, and then wait() for it. If the exit status
+    indicates that it stopped for any reason other than SIGTERM,
+    ``run_for_seconds`` returns False, otherwise it returns True.
+
+    This is useful to check that a server process does not immediately die on
+    startup, though it's a bit of a hack --- checking rigorously would require
+    extra knowledge of the workings of that process (hooray for the halting
+    problem).
+    """
+    proc = Popen(cmd)
+    sleep(seconds)
+    proc.terminate()
+    status = proc.wait()
+    return status == -signal.SIGTERM
+
+
+def test_serve():
+    check_call(['haas', 'init_db'])
+    assert runs_for_seconds(['haas', 'serve', '5000'], seconds=1)
+
+
+def test_serve_networks():
+    check_call(['haas', 'init_db'])
+    assert runs_for_seconds(['haas', 'serve_networks'], seconds=1)

--- a/tests/unit/rest.py
+++ b/tests/unit/rest.py
@@ -332,15 +332,25 @@ class TestValidationError(HttpTest):
 
 
 class TestCallOnce(HttpTest):
+    """Verify that the request handler invokes the API *exactly* once.
+
+    This is a regression test; A previous refactoring introduced a bug where
+    the api function was called twice.
+    """
 
     def setUp(self):
         HttpTest.setUp(self)
         self.num_calls = 0
 
     def test_call_once(self):
+        # We define an API call that increments a counter each time the
+        # function is called, then invoke it via HTTP. Finally, we verify that
+        # the counter is equal to 1, indicating that the function was called
+        # the correct number of times.
 
         @rest.rest_call('POST', '/increment')
-        def once():
+        def increment():
+            """Increment a counter each time this function is called."""
             self.num_calls += 1
 
         rest.request_handler(Request(wsgi_mkenv('POST', '/increment')))

--- a/tests/unit/rest.py
+++ b/tests/unit/rest.py
@@ -329,3 +329,19 @@ class TestValidationError(HttpTest):
         assert _is_error(self._do_request(json.dumps({
             'the_value': 'Not an integer!',
         })), rest.ValidationError)
+
+
+class TestCallOnce(HttpTest):
+
+    def setUp(self):
+        HttpTest.setUp(self)
+        self.num_calls = 0
+
+    def test_call_once(self):
+
+        @rest.rest_call('POST', '/increment')
+        def once():
+            self.num_calls += 1
+
+        rest.request_handler(Request(wsgi_mkenv('POST', '/increment')))
+        assert self.num_calls == 1


### PR DESCRIPTION
D'oh

The test suite didn't catch this because it mostly invokes the api calls directly; doesn't go through the http handler.

This is built on top of #477; that should be merged first.