### PR TITLE
add uuid/base_img to show_headnode

### DIFF
--- a/haas/api.py
+++ b/haas/api.py
@@ -877,7 +877,9 @@ def show_headnode(nodename):
         'project': headnode.project.label,
         'hnics': [n.label for n in headnode.hnics],
         'vncport': headnode.get_vncport(),
-    })
+        'uuid' : headnode.uuid,
+        'base_imgs': headnode.base_img,
+    }, sort_keys = True)
 
 
 @rest_call('GET', '/headnode_images/')


### PR DESCRIPTION
Added uuid and base_mg to show_headnode here.

I cannot have it output the virtual machine name for now, since, according to Sahil, I need to setup libvirt first and then I can do something with the name of virtual machine in show_headnode(). 


**For the unit test**, I am having trouble for write a unit test for the uuid in show_headnode() since uuid is a unique id and I cannot hard-code it in the unit test script for testing. 

Any suggestion would be much appreciated. 