### PR TITLE
Adding CLI call for switch_register

### DIFF
--- a/docs/USING.rst
+++ b/docs/USING.rst
@@ -55,7 +55,7 @@ been run succesfully.
 Usage Examples
 =================
 
-Included herewith are some examples about using some newly added cli and api calls. 
+Included herewith are some examples about using cli and api calls. 
 
 
 

--- a/docs/USING.rst
+++ b/docs/USING.rst
@@ -63,17 +63,17 @@ Included herewith are some examples about using cli and api calls.
 -------------------------------
 
 Eg> Switch name: mockswitch01
-     hostname: switchhost01
-     username: switchuser01
-     Password: password1234
+     Host name:  switchhost01
+     User name:  switchuser01
+     Password:   password1234
 
 api call
 
 ::
 
-    curl -X put http://127.0.0.1:5000/switch/mockswitch_fromapi -d '
+    curl -X put http://127.0.0.1:5000/switch/mockswitch01 -d '
         {"type": "http://schema.massopencloud.org/haas/v0/switches/mock",
-        "hostname": "switchHost01",
+        "hostname": "switchhost01",
         "username": "switchuser01",
         "password": "password1234"}'
 
@@ -81,7 +81,7 @@ cli call
 
 ::
 
-       haas switch_register mock03 mock switchHost01 switchuser01 password1234
+       haas switch_register mockswitch02 mock switchhost01 switchuser01 password1234
 
  
 

--- a/docs/USING.rst
+++ b/docs/USING.rst
@@ -50,3 +50,38 @@ to hard-disk booting the installed system.
 This is, as the filepath states, merely an example of how you might deploy to
 physical nodes.  Existing deployment systems such as Canonical's MAAS have also
 been run succesfully.
+
+
+Usage Examples
+=================
+
+Included herewith are some examples about using some newly added cli and api calls. 
+
+
+
+1) Register a switch with HaaS:
+-------------------------------
+
+Eg> Switch name: mockswitch01
+     hostname: switchhost01
+     username: switchuser01
+     Password: password1234
+
+api call
+
+::
+
+    curl -X put http://127.0.0.1:5000/switch/mockswitch_fromapi -d '
+        {"type": "http://schema.massopencloud.org/haas/v0/switches/mock",
+        "hostname": "switchHost01",
+        "username": "switchuser01",
+        "password": "password1234"}'
+
+cli call
+
+::
+       haas switch_register mock03 mock switchHost01 switchuser01 password1234
+
+ 
+
+

--- a/haas/api.py
+++ b/haas/api.py
@@ -899,6 +899,28 @@ def _assert_absent(cls, name):
 
     cls - the class of the object to query.
     name - the name of the object in question.
+    Stop logging output from the console and delete the log.
+    """
+    node = _must_find(model.Node, nodename)
+    node.stop_console()
+    node.delete_console()
+#    node.obm.stop_console()
+#    node.obm.delete_console()
+
+
+    # Helper functions #
+    ####################
+
+
+def _assert_absent(cls, name):
+    """Raises a DuplicateError if the given object is already in the database.
+
+    This is useful for most of the *_create functions.
+
+    Arguments:
+
+    cls - the class of the object to query.
+    name - the name of the object in question.
 
     Must be called within a request context.
     """

--- a/haas/api.py
+++ b/haas/api.py
@@ -899,26 +899,6 @@ def _assert_absent(cls, name):
 
     cls - the class of the object to query.
     name - the name of the object in question.
-    Stop logging output from the console and delete the log.
-    """
-    node = _must_find(model.Node, nodename)
-    node.stop_console()
-    node.delete_console()
-
-
-    # Helper functions #
-    ####################
-
-
-def _assert_absent(cls, name):
-    """Raises a DuplicateError if the given object is already in the database.
-
-    This is useful for most of the *_create functions.
-
-    Arguments:
-
-    cls - the class of the object to query.
-    name - the name of the object in question.
 
     Must be called within a request context.
     """

--- a/haas/api.py
+++ b/haas/api.py
@@ -904,8 +904,6 @@ def _assert_absent(cls, name):
     node = _must_find(model.Node, nodename)
     node.stop_console()
     node.delete_console()
-#    node.obm.stop_console()
-#    node.obm.delete_console()
 
 
     # Helper functions #

--- a/haas/cli.py
+++ b/haas/cli.py
@@ -311,6 +311,18 @@ def headnode_detach_network(headnode, hnic):
     do_post(url)
 
 @cmd
+def switch_register(switch, subtype, *args):
+    """Register a switch with name <switch> and
+    <subtype>, <hostname>, <username>,  <password>
+    eg. haas switch_register mock03 mock mockhost01 mockuser01 mockpass01
+    """
+    switch_api = "http://schema.massopencloud.org/haas/v0/switches/"
+    switchinfo = { "type": switch_api+subtype, "hostname": args[0],
+                        "username": args[1], "password": args[2] }
+    url = object_url('switch', switch)
+    do_put(url, data=switchinfo)
+
+@cmd
 def port_register(port):
     """Register a <port> on a switch"""
     url = object_url('port', port)

--- a/haas/ext/switches/mock.py
+++ b/haas/ext/switches/mock.py
@@ -20,7 +20,6 @@ Meant for use in the test suite.
 from collections import defaultdict
 from haas.model import Switch
 import schema
-#from schema import Schema
 from sqlalchemy import Column, Integer, ForeignKey, String
 
 LOCAL_STATE = defaultdict(lambda: defaultdict(dict))
@@ -53,10 +52,6 @@ class MockSwitch(Switch):
             'password': basestring,
         }).validate(kwargs)
 
-
-#    @staticmethod
-#    def validate(kwargs):
-#        Schema({}).validate(kwargs)
 
     def session(self):
         return self

--- a/haas/ext/switches/mock.py
+++ b/haas/ext/switches/mock.py
@@ -19,8 +19,9 @@ Meant for use in the test suite.
 
 from collections import defaultdict
 from haas.model import Switch
-from schema import Schema
-from sqlalchemy import Column, Integer, ForeignKey
+import schema
+#from schema import Schema
+from sqlalchemy import Column, Integer, ForeignKey, String
 
 LOCAL_STATE = defaultdict(lambda: defaultdict(dict))
 
@@ -32,17 +33,30 @@ class MockSwitch(Switch):
     It's implementation is connectionless, so it is it's own session object as
     suggested int the superclass's documentation.
     """
-    id = Column(Integer, ForeignKey('switch.id'), primary_key=True)
 
     api_name = 'http://schema.massopencloud.org/haas/v0/switches/mock'
 
     __mapper_args__ = {
         'polymorphic_identity': api_name,
     }
+    
+    id = Column(Integer, ForeignKey('switch.id'), primary_key=True)
+    hostname = Column(String, nullable=False)
+    username = Column(String, nullable=False)
+    password = Column(String, nullable=False)
 
     @staticmethod
     def validate(kwargs):
-        Schema({}).validate(kwargs)
+        schema.Schema({
+            'username': basestring,
+            'hostname': basestring,
+            'password': basestring,
+        }).validate(kwargs)
+
+
+#    @staticmethod
+#    def validate(kwargs):
+#        Schema({}).validate(kwargs)
 
     def session(self):
         return self

--- a/tests/unit/api.py
+++ b/tests/unit/api.py
@@ -190,7 +190,8 @@ class TestProjectAddDeleteUser:
 class TestNetworking:
 
     def test_networking_involved(self, db):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         for port in '1', '2', '3':
             api.switch_register_port('sw0', port)
         api.node_register('node-99', 'ipmihost', 'root', 'tapeworm')
@@ -996,21 +997,25 @@ class Test_switch_register:
 
     def test_basic(self, db):
         """Calling switch_register should create an object in the db."""
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         assert db.query(model.Switch).one().label == 'sw0'
 
     def test_duplicate(self, db):
         """switch_register should complain if asked to make a duplicate switch."""
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         with pytest.raises(api.DuplicateError):
-            api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+            api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
 
 
 class Test_switch_delete:
 
     def test_basic(self, db):
         """Deleting a switch should actually remove it."""
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_delete('sw0')
         assert db.query(model.Switch).count() == 0
 
@@ -1024,7 +1029,8 @@ class Test_switch_register_port:
 
     def test_basic(self, db):
         """Creating a port on an existing switch should succeed."""
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '5')
         port = db.query(model.Port).one()
         assert port.label == '5'
@@ -1040,7 +1046,8 @@ class Test_switch_delete_port:
 
     def test_basic(self, db):
         """Removing a port should remove it from the db."""
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '5')
         api.switch_delete_port('sw0', '5')
         assert db.query(model.Port).count() == 0
@@ -1052,7 +1059,8 @@ class Test_switch_delete_port:
 
     def test_port_nexist(self, db):
         """Removing a port that does not exist should report the error"""
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         with pytest.raises(api.NotFoundError):
             api.switch_delete_port('sw0', '5')
 
@@ -1060,7 +1068,8 @@ class Test_switch_delete_port:
 class TestPortConnectDetachNic:
 
     def test_port_connect_nic_success(self, db):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
         api.node_register('compute-01', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
@@ -1073,27 +1082,31 @@ class TestPortConnectDetachNic:
             api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_port(self, db):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         api.node_register('compute-01', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
         with pytest.raises(api.NotFoundError):
             api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_node(self, db):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
         with pytest.raises(api.NotFoundError):
             api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
     def test_port_connect_nic_no_such_nic(self, db):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
         api.node_register('compute-01', 'ipmihost', 'root', 'tapeworm')
         with pytest.raises(api.NotFoundError):
             api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
     def test_port_connect_nic_already_attached_to_same(self, db):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
         api.node_register('compute-01', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
@@ -1102,7 +1115,8 @@ class TestPortConnectDetachNic:
             api.port_connect_nic('sw0', '3', 'compute-01', 'eth0')
 
     def test_port_connect_nic_nic_already_attached_differently(self, db):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
         api.switch_register_port('sw0', '4')
         api.node_register('compute-01', 'ipmihost', 'root', 'tapeworm')
@@ -1112,7 +1126,8 @@ class TestPortConnectDetachNic:
             api.port_connect_nic('sw0', '4', 'compute-01', 'eth0')
 
     def test_port_connect_nic_port_already_attached_differently(self, db):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
         api.node_register('compute-01', 'ipmihost', 'root', 'tapeworm')
         api.node_register('compute-02', 'ipmihost', 'root', 'tapeworm')
@@ -1123,7 +1138,8 @@ class TestPortConnectDetachNic:
             api.port_connect_nic('sw0', '3', 'compute-02', 'eth1')
 
     def test_port_detach_nic_success(self, db):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
         api.node_register('compute-01', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
@@ -1135,7 +1151,8 @@ class TestPortConnectDetachNic:
             api.port_detach_nic('sw0', '3')
 
     def test_port_detach_nic_not_attached(self, db):
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
         api.node_register('compute-01', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')
@@ -1144,7 +1161,8 @@ class TestPortConnectDetachNic:
 
     def port_detach_nic_node_not_free(self, db):
         """should refuse to detach a nic if it has pending actions."""
-        api.switch_register('sw0', type=MOCK_SWITCH_TYPE)
+        api.switch_register('sw0', type=MOCK_SWITCH_TYPE, 
+		username="switch_user", password="switch_pass", hostname="switchname")
         api.switch_register_port('sw0', '3')
         api.node_register('compute-01', 'ipmihost', 'root', 'tapeworm')
         api.node_register_nic('compute-01', 'eth0', 'DE:AD:BE:EF:20:14')


### PR DESCRIPTION
Updates same as #528.
#528 was mistakenly branched from a non-master branch. Thus it contained lot of stuff that should not be there.

Will delete that pull request. Replacing #528 with this pull request.

The following commit:
	1) modifies the mock switch driver to resemble a real switch driver
	2) Adjusted the unit tests to accomodate extra arguments from switch driver
 	3) Added cli call corresponding to api call for switch register
	4) Updated docs/USING.rst with an example on how to use it via API and cli calls.

