### PR TITLE
Brocade Driver

### DIFF
--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -1,0 +1,179 @@
+# Copyright 2016 Massachusetts Open Cloud Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS
+# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""A switch driver for Brocade NOS.
+
+Uses the XML REST API for communicating with the switch.
+"""
+
+import logging
+from lxml import etree
+from os.path import dirname, join
+import re
+import requests
+import schema
+
+from haas.migrations import paths
+from haas.model import db, Switch
+
+paths[__name__] = join(dirname(__file__), 'migrations', 'brocade')
+
+logger = logging.getLogger(__name__)
+
+
+class Brocade(Switch):
+    api_name = 'http://schema.massopencloud.org/haas/v0/switches/brocade'
+
+    __mapper_args__ = {
+        'polymorphic_identity': api_name,
+    }
+
+    id = db.Column(db.Integer, db.ForeignKey('switch.id'), primary_key=True)
+    hostname = db.Column(db.String, nullable=False)
+    username = db.Column(db.String, nullable=False)
+    password = db.Column(db.String, nullable=False)
+    interface_type = db.Column(db.String, nullable=False)
+
+    @staticmethod
+    def validate(kwargs):
+        schema.Schema({
+            'hostname': basestring,
+            'username': basestring,
+            'password': basestring,
+            'interface_type': basestring,
+        }).validate(kwargs)
+
+    def session(self):
+        return self
+
+    def disconnect(self):
+        pass
+
+    def apply_networking(self, action):
+        interface = action.nic.port.label
+        channel = action.channel
+
+        if channel == 'vlan/native':
+            if action.new_network is None:
+                self._remove_native_vlan(interface)
+            else:
+                self._set_native_vlan(interface,
+                                      action.new_network.network_id)
+        else:
+            match = re.match(re.compile(r'vlan/(\d+)'), channel)
+            assert match is not None, "HaaS passed an invalid channel to the switch!"
+            vlan_id = match.groups()[0]
+
+            if action.new_network is None:
+                self._remove_vlan_from_trunk(interface, vlan_id)
+            else:
+                assert action.new_network.network_id == vlan_id
+                self._add_vlan_to_trunk(interface, vlan_id)
+
+    def get_port_networks(self, ports):
+        """Get port configurations of the switch.
+
+        Args:
+            ports: List of ports to get the configuration for.
+
+        Returns: Dictionary containing the configuration of the form:
+        {
+            Port<"port-3">: [("vlan/native", "23"), ("vlan/52", "52")],
+            Port<"port-7">: [("vlan/23", "23")],
+            Port<"port-8">: [("vlan/native", "52")],
+            ...
+        }
+
+        """
+        response = {}
+        for port in ports:
+            response[port] = filter(None, [self._get_native_vlan(port)]) \
+                             + self._get_vlans(port)
+        return response
+
+    def _get_mode(self, interface):
+        url = self._construct_url(interface, suffix='mode')
+        response = requests.get(url, auth=self._auth)
+        root = etree.fromstring(response.text)
+        mode = root.find(self._construct_tag('vlan-mode')).text
+        return mode
+
+    def _set_mode(self, interface, mode):
+        if mode in ['access', 'trunk']:
+            url = self._construct_url(interface, suffix='mode')
+            payload = '<mode><vlan-mode>%s</vlan-mode></mode>' % mode
+            requests.put(url, data=payload, auth=self._auth)
+        else:
+            raise AssertionError('Invalid mode')
+
+    def _get_vlans(self, interface):
+        try:
+            url = self._construct_url(interface, suffix='trunk')
+            response = requests.get(url, auth=self._auth)
+            root = etree.fromstring(response.text)
+            vlans = root.\
+                find(self._construct_tag('allowed')).\
+                find(self._construct_tag('vlan')).\
+                find(self._construct_tag('add')).text
+            return [('vlan/%s' % x, x) for x in vlans.split(',')]
+        except AttributeError:
+            return []
+
+    def _get_native_vlan(self, interface):
+        try:
+            url = self._construct_url(interface, suffix='trunk')
+            response = requests.get(url, auth=self._auth)
+            root = etree.fromstring(response.text)
+            vlan = root.find(self._construct_tag('native-vlan')).text
+            return ('vlan/native', vlan)
+        except AttributeError:
+            return None
+
+    def _add_vlan_to_trunk(self, interface, vlan):
+        self._set_mode(interface, 'trunk')
+        url = self._construct_url(interface, suffix='trunk/allowed/vlan')
+        payload = '<vlan><add>%s</vlan></vlan>' % vlan
+        requests.put(url, data=payload, auth=self._auth)
+
+    def _remove_vlan_from_trunk(self, interface, vlan):
+        url = self._construct_url(interface, suffix='trunk/allowed/vlan')
+        payload = '<vlan><remove>%s</remove></vlan>' % vlan
+        requests.put(url, data=payload, auth=self._auth)
+
+    def _set_native_vlan(self, interface, vlan):
+        self._set_mode(interface, 'trunk')
+        url = self._construct_url(interface, suffix='trunk')
+        payload = '<trunk><native-vlan>%s</native-vlan></trunk>' % vlan
+        requests.put(url, data=payload, auth=self._auth)
+
+    def _remove_native_vlan(self, interface):
+        url = self._construct_url(interface, suffix='trunk/native-vlan')
+        requests.delete(url, auth=self._auth)
+
+    def _construct_url(self, interface, suffix=None):
+        return '%(hostname)s/rest/config/running/interface/' \
+              '%(interface_type)s/%%22%(interface)s%%22/switchport/%(suffix)s' % {
+                  'hostname': self.hostname,
+                  'interface_type': self.interface_type,
+                  'interface': interface,
+                  'suffix': suffix
+        }
+
+    @property
+    def _auth(self):
+        return self.username, self.password
+
+    @staticmethod
+    def _construct_tag(name):
+        return '{urn:brocade.com:mgmt:brocade-interface}%s' % name

--- a/haas/ext/switches/migrations/brocade/5a6db7a7222d_added_brocade_driver.py
+++ b/haas/ext/switches/migrations/brocade/5a6db7a7222d_added_brocade_driver.py
@@ -8,7 +8,7 @@ Create Date: 2016-04-11 16:26:40.715332
 
 # revision identifiers, used by Alembic.
 revision = '5a6db7a7222d'
-down_revision = '6a8c19565060'
+down_revision = None
 branch_labels = ('haas.ext.switches.brocade',)
 
 from alembic import op

--- a/haas/ext/switches/migrations/brocade/5a6db7a7222d_added_brocade_driver.py
+++ b/haas/ext/switches/migrations/brocade/5a6db7a7222d_added_brocade_driver.py
@@ -1,0 +1,31 @@
+"""Added Brocade driver
+
+Revision ID: 5a6db7a7222d
+Revises: 6a8c19565060
+Create Date: 2016-04-11 16:26:40.715332
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '5a6db7a7222d'
+down_revision = '6a8c19565060'
+branch_labels = ('haas.ext.switches.brocade',)
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'brocade',
+        sa.Column('id', sa.Integer(), nullable=False, autoincrement=False),
+        sa.Column('hostname', sa.String(), nullable=False),
+        sa.Column('username', sa.String(), nullable=False),
+        sa.Column('password', sa.String(), nullable=False),
+        sa.Column('interface_type', sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade():
+    op.drop_table('brocade')

--- a/setup.py
+++ b/setup.py
@@ -74,4 +74,6 @@ setup(name='haas',
                         'pytest>=2.6.2,<3.0',
                         'pytest-cov==1.8.0',
                         'pytest-xdist',
+                        'requests_mock',
+                        'lxml'
                         ])

--- a/tests/unit/ext/switches/brocade.py
+++ b/tests/unit/ext/switches/brocade.py
@@ -19,80 +19,109 @@ from haas.ext.switches import brocade
 from haas import model
 from haas.ext.obm.ipmi import Ipmi
 
-MODE_RESPONSE_ACCESS = """
-<mode xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest" y:self="/rest/config/running/interface/TenGigabitEthernet/%22101/0/10%22/switchport/mode">
-    <vlan-mode>access</vlan-mode>
-    <private-vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22101/0/10%22/switchport/mode/private-vlan">
-        <trunk y:self="/rest/config/running/interface/TenGigabitEthernet/%22101/0/10%22/switchport/mode/private-vlan/trunk"/>
-    </private-vlan>
-</mode>"""
+MODE_RESPONSE_ACCESS = (
+    '<mode xmlns="urn:brocade.com:mgmt:brocade-interface" '
+    'xmlns:y="http://brocade.com/ns/rest" '
+    'y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22101/0/10%22/switchport/mode">\n'
+    '  <vlan-mode>access</vlan-mode>\n'
+    '  <private-vlan '
+    'y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22101/0/10%22/switchport/mode/private-vlan">\n'
+    '    <trunk '
+    'y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22101/0/10%22/switchport/mode/private-vlan/trunk"/>\n'
+    '  </private-vlan>\n'
+    '</mode>'
+)
 
-MODE_RESPONSE_TRUNK = """
-<mode xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest" y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/mode">
-    <vlan-mode>trunk</vlan-mode>
-    <private-vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/mode/private-vlan">
-        <trunk y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/mode/private-vlan/trunk"/>
-    </private-vlan>
-</mode>"""
+MODE_RESPONSE_TRUNK = (
+    '<mode xmlns="urn:brocade.com:mgmt:brocade-interface" '
+    'xmlns:y="http://brocade.com/ns/rest" '
+    'y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/18%22/switchport/mode">\n'
+    '  <vlan-mode>trunk</vlan-mode>\n'
+    '  <private-vlan '
+    'y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/18%22/switchport/mode/private-vlan">\n'
+    '    <trunk '
+    'y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/18%22/switchport/mode/private-vlan/trunk"/>\n'
+    '  </private-vlan>\n'
+    '</mode>'
+)
 
-TRUNK_VLAN_RESPONSE = """
-<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest" y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk">
+TRUNK_VLAN_RESPONSE = (
+    '<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" '
+    'xmlns:y="http://brocade.com/ns/rest" '
+    'y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/18%22/switchport/trunk">\n'
+    ' <allowed y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/18%22/switchport/trunk/allowed">\n'
+    '  <rspan-vlan y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/18%22/switchport/trunk/allowed/rspan-vlan"/>\n'
+    '  <vlan y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/18%22/switchport/trunk/allowed/vlan">\n'
+    '   <add>1,4001,4004,4025,4050</add>\n'
+    '  </vlan>\n'
+    ' </allowed>\n'
+    ' <tag y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/18%22/switchport/trunk/tag">\n'
+    ' <native-vlan>true</native-vlan>\n'
+    '</tag>\n'
+    '</trunk>'
+)
 
-  <allowed y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/allowed">
-    <rspan-vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/allowed/rspan-vlan"/>
-    <vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/allowed/vlan">
-      <add>1,4001,4004,4025,4050</add>
-    </vlan>
-  </allowed>
+ACCESS_VLAN_RESPONSE = (
+    '<access xmlns="urn:brocade.com:mgmt:brocade-interface" '
+    'xmlns:y="http://brocade.com/ns/rest" '
+    'y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22101/0/10%22/switchport/access">\n'
+    '  <vlan>10</vlan>\n'
+    '</access>'
+)
 
-  <tag y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/tag">
-    <native-vlan>true</native-vlan>
-  </tag>
+TRUNK_NATIVE_VLAN_RESPONSE_NO_VLANS = (
+    '<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" '
+    'xmlns:y="http://brocade.com/ns/rest" '
+    'y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/10%22/switchport/trunk">\n'
+    ' <allowed y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/10%22/switchport/trunk/allowed">\n'
+    '  <rspan-vlan y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/10%22/switchport/trunk/allowed/rspan-vlan"/>\n'
+    '  <vlan y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/10%22/switchport/trunk/allowed/vlan"/>\n'
+    ' </allowed>\n'
+    ' <tag y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/10%22/switchport/trunk/tag">\n'
+    '  <native-vlan>true</native-vlan>\n'
+    '   </tag>\n'
+    '  <native-vlan>10</native-vlan>\n'
+    '</trunk>'
+)
 
-</trunk>
-"""
-
-ACCESS_VLAN_RESPONSE = """
-<access xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest" y:self="/rest/config/running/interface/TenGigabitEthernet/%22101/0/10%22/switchport/access">
-    <vlan>10</vlan>
-</access>
-"""
-
-TRUNK_NATIVE_VLAN_RESPONSE_NO_VLANS = """
-<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest" y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk">
-
-  <allowed y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed">
-    <rspan-vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed/rspan-vlan"/>
-    <vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed/vlan"/>
-  </allowed>
-
-  <tag y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/tag">
-    <native-vlan>true</native-vlan>
-  </tag>
-
-  <native-vlan>10</native-vlan>
-
-</trunk>
-"""
-
-TRUNK_NATIVE_VLAN_RESPONSE_WITH_VLANS = """
-<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest" y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk">
-
-  <allowed y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed">
-    <rspan-vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed/rspan-vlan"/>
-    <vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed/vlan">
-      <add>4001,4025</add>
-    </vlan>
-  </allowed>
-
-  <tag y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/tag">
-    <native-vlan>true</native-vlan>
-  </tag>
-
-  <native-vlan>10</native-vlan>
-
-</trunk>
-"""
+TRUNK_NATIVE_VLAN_RESPONSE_WITH_VLANS = (
+    '<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" '
+    'xmlns:y="http://brocade.com/ns/rest" '
+    'y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/10%22/switchport/trunk">\n'
+    ' <allowed y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/10%22/switchport/trunk/allowed">\n'
+    '  <rspan-vlan y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/10%22/switchport/trunk/allowed/rspan-vlan"/>\n'
+    '  <vlan y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/10%22/switchport/trunk/allowed/vlan">\n'
+    '   <add>4001,4025</add>\n'
+    '  </vlan>\n'
+    ' </allowed>\n'
+    ' <tag y:self="/rest/config/running/interface/TenGigabitEthernet'
+    '/%22104/0/10%22/switchport/trunk/tag">\n'
+    '  <native-vlan>true</native-vlan>\n'
+    ' </tag>\n'
+    ' <native-vlan>10</native-vlan>\n'
+    '</trunk>'
+)
 
 TRUNK_PAYLOAD = '<mode><vlan-mode>trunk</vlan-mode></mode>'
 
@@ -108,6 +137,27 @@ INTERFACE3 = '104/0/20'
 
 
 class TestBrocade(object):
+    """ Unit tests for the Brocade driver.
+
+    The tests use the requests_mock library to return prerecorded responses
+    from the switch (without any actual communication with the switch
+    happening during the tests), or check that the correct payload was sent
+    to the switch, at the right url.
+
+    Inside the `requests_mock.mock()` context, every call made with the requests
+    library will be directed to the mock object. We then register the urls
+    we want to mock, and what to return when they are requested. An exception
+    will be thrown if a request goes to a non-registered url.
+
+    Example below will return the PRERECORDER_RESPONSE string.
+    ```
+    with requests_mock.mock() as mock:
+        # Register the url and the text we want to return on a get
+        # request to it
+        mock.get(url, text=PRERECORDED_RESPONSE)
+        r = requests.get(url)
+    ```
+    """
     @pytest.fixture()
     def switch(self):
         return brocade.Brocade(
@@ -122,10 +172,11 @@ class TestBrocade(object):
         return model.Nic(
             model.Node(
                 label='node-99',
-                obm=Ipmi(type="http://schema.massopencloud.org/haas/v0/obm/ipmi",
-                         host="ipmihost",
-                         user="root",
-                         password="tapeworm")),
+                obm=Ipmi(
+                    type="http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                    host="ipmihost",
+                    user="root",
+                    password="tapeworm")),
             'ipmi',
             '00:11:22:33:44:55')
 
@@ -196,7 +247,8 @@ class TestBrocade(object):
                                                       new_network=None,
                                                       channel='vlan/native')
         with requests_mock.mock() as mock:
-            url_native = switch._construct_url(INTERFACE1, suffix='trunk/native-vlan')
+            url_native = switch._construct_url(INTERFACE1,
+                                               suffix='trunk/native-vlan')
             mock.delete(url_native)
 
             switch.apply_networking(action_rm_native)
@@ -209,9 +261,11 @@ class TestBrocade(object):
                                          new_network=network,
                                          channel='vlan/102')
         with requests_mock.mock() as mock:
-            url_mode = switch._construct_url(INTERFACE1, suffix='mode')
+            url_mode = switch._construct_url(INTERFACE1,
+                                             suffix='mode')
             mock.put(url_mode)
-            url_trunk = switch._construct_url(INTERFACE1, suffix='trunk/allowed/vlan')
+            url_trunk = switch._construct_url(INTERFACE1,
+                                              suffix='trunk/allowed/vlan')
             mock.put(url_trunk)
 
             switch.apply_networking(action_vlan)
@@ -226,7 +280,8 @@ class TestBrocade(object):
                                                 new_network=None,
                                                 channel='vlan/102')
         with requests_mock.mock() as mock:
-            url_trunk = switch._construct_url(INTERFACE1, suffix='trunk/allowed/vlan')
+            url_trunk = switch._construct_url(INTERFACE1,
+                                              suffix='trunk/allowed/vlan')
             mock.put(url_trunk)
 
             switch.apply_networking(action_rm_vlan)

--- a/tests/unit/ext/switches/brocade.py
+++ b/tests/unit/ext/switches/brocade.py
@@ -19,109 +19,83 @@ from haas.ext.switches import brocade
 from haas import model
 from haas.ext.obm.ipmi import Ipmi
 
-MODE_RESPONSE_ACCESS = (
-    '<mode xmlns="urn:brocade.com:mgmt:brocade-interface" '
-    'xmlns:y="http://brocade.com/ns/rest" '
-    'y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22101/0/10%22/switchport/mode">\n'
-    '  <vlan-mode>access</vlan-mode>\n'
-    '  <private-vlan '
-    'y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22101/0/10%22/switchport/mode/private-vlan">\n'
-    '    <trunk '
-    'y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22101/0/10%22/switchport/mode/private-vlan/trunk"/>\n'
-    '  </private-vlan>\n'
-    '</mode>'
-)
+MODE_RESPONSE_ACCESS = """
+<mode xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest"
+y:self="/rest/config/running/interface/TenGigabitEthernet/%22101/0/10%22/switchport/mode">
+  <vlan-mode>access</vlan-mode>
+  <private-vlan
+  y:self="/rest/config/running/interface/TenGigabitEthernet/%22101/0/10%22/switchport/mode/private-vlan">
+    <trunk
+    y:self="/rest/config/running/interface/TenGigabitEthernet/%22101/0/10%22/switchport/mode/private-vlan/trunk"/>
+  </private-vlan>
+</mode>
+"""
 
-MODE_RESPONSE_TRUNK = (
-    '<mode xmlns="urn:brocade.com:mgmt:brocade-interface" '
-    'xmlns:y="http://brocade.com/ns/rest" '
-    'y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/18%22/switchport/mode">\n'
-    '  <vlan-mode>trunk</vlan-mode>\n'
-    '  <private-vlan '
-    'y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/18%22/switchport/mode/private-vlan">\n'
-    '    <trunk '
-    'y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/18%22/switchport/mode/private-vlan/trunk"/>\n'
-    '  </private-vlan>\n'
-    '</mode>'
-)
+MODE_RESPONSE_TRUNK = """
+<mode xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest"
+y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/mode">
+  <vlan-mode>trunk</vlan-mode>
+  <private-vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/mode/private-vlan">
+    <trunk
+    y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/mode/private-vlan/trunk"/>
+  </private-vlan>
+</mode>
+"""
 
-TRUNK_VLAN_RESPONSE = (
-    '<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" '
-    'xmlns:y="http://brocade.com/ns/rest" '
-    'y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/18%22/switchport/trunk">\n'
-    ' <allowed y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/18%22/switchport/trunk/allowed">\n'
-    '  <rspan-vlan y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/18%22/switchport/trunk/allowed/rspan-vlan"/>\n'
-    '  <vlan y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/18%22/switchport/trunk/allowed/vlan">\n'
-    '   <add>1,4001,4004,4025,4050</add>\n'
-    '  </vlan>\n'
-    ' </allowed>\n'
-    ' <tag y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/18%22/switchport/trunk/tag">\n'
-    ' <native-vlan>true</native-vlan>\n'
-    '</tag>\n'
-    '</trunk>'
-)
+TRUNK_VLAN_RESPONSE = """
+<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest"
+y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk">
+  <allowed y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/allowed">
+    <rspan-vlan
+    y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/allowed/rspan-vlan"/>
+    <vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/allowed/vlan">
+      <add>1,4001,4004,4025,4050</add>
+    </vlan>
+  </allowed>
+  <tag y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/tag">
+    <native-vlan>true</native-vlan>
+  </tag>
+</trunk>
+"""
 
-ACCESS_VLAN_RESPONSE = (
-    '<access xmlns="urn:brocade.com:mgmt:brocade-interface" '
-    'xmlns:y="http://brocade.com/ns/rest" '
-    'y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22101/0/10%22/switchport/access">\n'
-    '  <vlan>10</vlan>\n'
-    '</access>'
-)
+ACCESS_VLAN_RESPONSE = """
+<access xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest"
+y:self="/rest/config/running/interface/TenGigabitEthernet/%22101/0/10%22/switchport/access">
+  <vlan>10</vlan>
+</access>
+"""
 
-TRUNK_NATIVE_VLAN_RESPONSE_NO_VLANS = (
-    '<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" '
-    'xmlns:y="http://brocade.com/ns/rest" '
-    'y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/10%22/switchport/trunk">\n'
-    ' <allowed y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/10%22/switchport/trunk/allowed">\n'
-    '  <rspan-vlan y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/10%22/switchport/trunk/allowed/rspan-vlan"/>\n'
-    '  <vlan y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/10%22/switchport/trunk/allowed/vlan"/>\n'
-    ' </allowed>\n'
-    ' <tag y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/10%22/switchport/trunk/tag">\n'
-    '  <native-vlan>true</native-vlan>\n'
-    '   </tag>\n'
-    '  <native-vlan>10</native-vlan>\n'
-    '</trunk>'
-)
+TRUNK_NATIVE_VLAN_RESPONSE_NO_VLANS = """
+<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest"
+y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk">
+  <allowed y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed">
+    <rspan-vlan
+    y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed/rspan-vlan"/>
+    <vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed/vlan"/>
+  </allowed>
+  <tag y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/tag">
+    <native-vlan>true</native-vlan>
+  </tag>
+  <native-vlan>10</native-vlan>
+</trunk>
+"""
 
-TRUNK_NATIVE_VLAN_RESPONSE_WITH_VLANS = (
-    '<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" '
-    'xmlns:y="http://brocade.com/ns/rest" '
-    'y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/10%22/switchport/trunk">\n'
-    ' <allowed y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/10%22/switchport/trunk/allowed">\n'
-    '  <rspan-vlan y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/10%22/switchport/trunk/allowed/rspan-vlan"/>\n'
-    '  <vlan y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/10%22/switchport/trunk/allowed/vlan">\n'
-    '   <add>4001,4025</add>\n'
-    '  </vlan>\n'
-    ' </allowed>\n'
-    ' <tag y:self="/rest/config/running/interface/TenGigabitEthernet'
-    '/%22104/0/10%22/switchport/trunk/tag">\n'
-    '  <native-vlan>true</native-vlan>\n'
-    ' </tag>\n'
-    ' <native-vlan>10</native-vlan>\n'
-    '</trunk>'
-)
+TRUNK_NATIVE_VLAN_RESPONSE_WITH_VLANS = """
+<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest"
+y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk">
+  <allowed y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed">
+    <rspan-vlan
+    y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed/rspan-vlan"/>
+    <vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed/vlan">
+      <add>4001,4025</add>
+    </vlan>
+  </allowed>
+  <tag y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/tag">
+    <native-vlan>true</native-vlan>
+  </tag>
+  <native-vlan>10</native-vlan>
+</trunk>
+"""
 
 TRUNK_PAYLOAD = '<mode><vlan-mode>trunk</vlan-mode></mode>'
 

--- a/tests/unit/ext/switches/brocade.py
+++ b/tests/unit/ext/switches/brocade.py
@@ -1,0 +1,229 @@
+# Copyright 2016 Massachusetts Open Cloud Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS
+# IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import pytest
+import requests_mock
+
+from haas.ext.switches import brocade
+from haas import model
+from haas.ext.obm.ipmi import Ipmi
+
+MODE_RESPONSE_ACCESS = """
+<mode xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest" y:self="/rest/config/running/interface/TenGigabitEthernet/%22101/0/10%22/switchport/mode">
+    <vlan-mode>access</vlan-mode>
+    <private-vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22101/0/10%22/switchport/mode/private-vlan">
+        <trunk y:self="/rest/config/running/interface/TenGigabitEthernet/%22101/0/10%22/switchport/mode/private-vlan/trunk"/>
+    </private-vlan>
+</mode>"""
+
+MODE_RESPONSE_TRUNK = """
+<mode xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest" y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/mode">
+    <vlan-mode>trunk</vlan-mode>
+    <private-vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/mode/private-vlan">
+        <trunk y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/mode/private-vlan/trunk"/>
+    </private-vlan>
+</mode>"""
+
+TRUNK_VLAN_RESPONSE = """
+<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest" y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk">
+
+  <allowed y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/allowed">
+    <rspan-vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/allowed/rspan-vlan"/>
+    <vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/allowed/vlan">
+      <add>1,4001,4004,4025,4050</add>
+    </vlan>
+  </allowed>
+
+  <tag y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/18%22/switchport/trunk/tag">
+    <native-vlan>true</native-vlan>
+  </tag>
+
+</trunk>
+"""
+
+ACCESS_VLAN_RESPONSE = """
+<access xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest" y:self="/rest/config/running/interface/TenGigabitEthernet/%22101/0/10%22/switchport/access">
+    <vlan>10</vlan>
+</access>
+"""
+
+TRUNK_NATIVE_VLAN_RESPONSE_NO_VLANS = """
+<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest" y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk">
+
+  <allowed y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed">
+    <rspan-vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed/rspan-vlan"/>
+    <vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed/vlan"/>
+  </allowed>
+
+  <tag y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/tag">
+    <native-vlan>true</native-vlan>
+  </tag>
+
+  <native-vlan>10</native-vlan>
+
+</trunk>
+"""
+
+TRUNK_NATIVE_VLAN_RESPONSE_WITH_VLANS = """
+<trunk xmlns="urn:brocade.com:mgmt:brocade-interface" xmlns:y="http://brocade.com/ns/rest" y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk">
+
+  <allowed y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed">
+    <rspan-vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed/rspan-vlan"/>
+    <vlan y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/allowed/vlan">
+      <add>4001,4025</add>
+    </vlan>
+  </allowed>
+
+  <tag y:self="/rest/config/running/interface/TenGigabitEthernet/%22104/0/10%22/switchport/trunk/tag">
+    <native-vlan>true</native-vlan>
+  </tag>
+
+  <native-vlan>10</native-vlan>
+
+</trunk>
+"""
+
+TRUNK_PAYLOAD = '<mode><vlan-mode>trunk</vlan-mode></mode>'
+
+TRUNK_NATIVE_PAYLOAD = '<trunk><native-vlan>102</native-vlan></trunk>'
+
+TRUNK_VLAN_PAYLOAD = '<vlan><add>102</vlan></vlan>'
+
+TRUNK_REMOVE_VLAN_PAYLOAD = '<vlan><remove>102</remove></vlan>'
+
+INTERFACE1 = '104/0/10'
+INTERFACE2 = '104/0/18'
+INTERFACE3 = '104/0/20'
+
+
+class TestBrocade(object):
+    @pytest.fixture()
+    def switch(self):
+        return brocade.Brocade(
+            hostname='http://example.com',
+            username='admin',
+            password='admin',
+            interface_type='TenGigabitEthernet'
+        ).session()
+
+    def test_get_port_networks(self, switch):
+        with requests_mock.mock() as mock:
+            mock.get(switch._construct_url(INTERFACE1, suffix='trunk'),
+                     text=TRUNK_NATIVE_VLAN_RESPONSE_WITH_VLANS)
+            mock.get(switch._construct_url(INTERFACE2, suffix='trunk'),
+                     text=TRUNK_NATIVE_VLAN_RESPONSE_NO_VLANS)
+            mock.get(switch._construct_url(INTERFACE3, suffix='trunk'),
+                     text=TRUNK_VLAN_RESPONSE)
+            response = switch.get_port_networks([INTERFACE1,
+                                                 INTERFACE2,
+                                                 INTERFACE3])
+            assert response == {
+                INTERFACE1: [('vlan/native', '10'),
+                             ('vlan/4001', '4001'),
+                             ('vlan/4025', '4025')],
+                INTERFACE2: [('vlan/native', '10')],
+                INTERFACE3: [('vlan/1', '1'),
+                             ('vlan/4001', '4001'),
+                             ('vlan/4004', '4004'),
+                             ('vlan/4025', '4025'),
+                             ('vlan/4050', '4050')]
+            }
+
+    def test_get_mode(self, switch):
+        with requests_mock.mock() as mock:
+            mock.get(switch._construct_url(INTERFACE1, suffix='mode'),
+                     text=MODE_RESPONSE_ACCESS)
+            response = switch._get_mode(INTERFACE1)
+            assert response == 'access'
+
+            mock.get(switch._construct_url(INTERFACE1, suffix='mode'),
+                     text=MODE_RESPONSE_TRUNK)
+            response = switch._get_mode(INTERFACE1)
+            assert response == 'trunk'
+
+    def test_apply_networking(self, switch):
+        # Note(knikolla): Create a Nic connected to the Switch
+        port = model.Port(label=INTERFACE1, switch=switch)
+        nic = model.Nic(
+            model.Node(label='node-99',
+                       obm=Ipmi(type="http://schema.massopencloud.org/haas/v0/obm/ipmi",
+                                host="ipmihost",
+                                user="root",
+                                password="tapeworm")),
+            'ipmi',
+            '00:11:22:33:44:55')
+        nic.port = port
+        project = model.Project('anvil-nextgen')
+        network = model.Network(project, project, True, '102', 'hammernet')
+
+        # Test action to set a network as native
+        action_native = model.NetworkingAction(nic=nic,
+                                               new_network=network,
+                                               channel='vlan/native')
+        with requests_mock.mock() as mock:
+            url_mode = switch._construct_url(INTERFACE1, suffix='mode')
+            mock.put(url_mode)
+            url_trunk = switch._construct_url(INTERFACE1, suffix='trunk')
+            mock.put(url_trunk)
+
+            switch.apply_networking(action_native)
+
+            assert mock.called
+            assert mock.call_count == 2
+            assert mock.request_history[0].text == TRUNK_PAYLOAD
+            assert mock.request_history[1].text == TRUNK_NATIVE_PAYLOAD
+
+        # Test action to remove a native network
+        action_rm_native = model.NetworkingAction(nic=nic,
+                                                      new_network=None,
+                                                      channel='vlan/native')
+        with requests_mock.mock() as mock:
+            url_native = switch._construct_url(INTERFACE1, suffix='trunk/native-vlan')
+            mock.delete(url_native)
+
+            switch.apply_networking(action_rm_native)
+
+            assert mock.called
+            assert mock.call_count == 1
+
+        # Test action to add a vlan
+        action_vlan = model.NetworkingAction(nic=nic,
+                                         new_network=network,
+                                         channel='vlan/102')
+        with requests_mock.mock() as mock:
+            url_mode = switch._construct_url(INTERFACE1, suffix='mode')
+            mock.put(url_mode)
+            url_trunk = switch._construct_url(INTERFACE1, suffix='trunk/allowed/vlan')
+            mock.put(url_trunk)
+
+            switch.apply_networking(action_vlan)
+
+            assert mock.called
+            assert mock.call_count == 2
+            assert mock.request_history[0].text == TRUNK_PAYLOAD
+            assert mock.request_history[1].text == TRUNK_VLAN_PAYLOAD
+
+        # Test action to remove a vlan
+        action_rm_vlan = model.NetworkingAction(nic=nic,
+                                                new_network=None,
+                                                channel='vlan/102')
+        with requests_mock.mock() as mock:
+            url_trunk = switch._construct_url(INTERFACE1, suffix='trunk/allowed/vlan')
+            mock.put(url_trunk)
+
+            switch.apply_networking(action_rm_vlan)
+
+            assert mock.called
+            assert mock.call_count == 1
+            assert mock.request_history[0].text == TRUNK_REMOVE_VLAN_PAYLOAD


### PR DESCRIPTION
Starting development of the Brocade Driver for HaaS.

LAST UPDATE (05/10/2016): The individual methods required for interacting with the switch have been implemented and tests. What hasn't been tested is the apply_networking method, which takes an action from HaaS and applies it to the switch. That part of the driver has been copy pasted with minor refactoring from console based switches, but should still work.