### PR TITLE
Basic API Logging

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -87,6 +87,9 @@ important: ``trunk_nic`` must match your choice of trunk NIC in the "Networking
 For a detailed description of the configuration needed for various switch
 setups, see ``docs/network-drivers.md``.
 
+Logging level and directory can be set in the ``[general]`` section. For more
+information view ``docs/logging.md``.
+
 The file should be placed at ``/etc/haas.cfg``; The ``haas.wsgi``
 script, described below, requires this. Awkwardly, the ``haas``
 command line tool expects the file to be present in its current

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,29 @@
+# Overview
+HaaS supports basic logging of the API calls received in the below format,
+recording the user who issued the API call (or guest if the user was
+unauthenticated) and the time. Log files are rotated daily.
+
+```
+2016-03-31 14:55:07,961 - haas.rest - INFO - (guest) - API call: list_projects()
+```
+
+# Setup
+Logging can be configured with the following options in `haas.cfg`.
+
+```
+[general]
+log_level = DEBUG
+log_dir = /var/log/haas
+```
+
+`log_dir` specifies the directory where the log files will be stored.
+The HaaS user must have write permissions to this directory.
+If the option is omitted logging to files is disabled.
+
+`log_level` specifies the logging level to record. Valid options are:
+`CRITICAL`, `DEBUG`, `ERROR`, `FATAL`, `INFO`, `WARN`, `WARNING`.
+The default value is `WARNING`, but an option of `INFO` is recommended
+for an API log (A log level of `INFO` is set for API calls).
+
+For more information on logging visit the
+[python 2 documentation](https://docs.python.org/2/howto/logging.html#when-to-use-logging).

--- a/haas/auth.py
+++ b/haas/auth.py
@@ -42,10 +42,18 @@ class AuthBackend(object):
         """
 
     @abstractmethod
+    def get_user(self):
+        """Return a string with the currently authenticated user.
+
+        Return String with username of the currently authenticated user,
+        or None if no user is authenticated.
+        """
+
+    @abstractmethod
     def _have_admin(self):
         """Check if the request is authorized to act as an administrator.
 
-        Return True if so, False if not. This will be caled sometime after
+        Return True if so, False if not. This will be called sometime after
         ``authenticate()``.
         """
 

--- a/haas/config.py
+++ b/haas/config.py
@@ -21,7 +21,9 @@ Once `load` has been called, it will be ready to use.
 
 import ConfigParser
 import logging
+from logging import handlers
 import importlib
+import os
 import sys
 
 cfg = ConfigParser.RawConfigParser()
@@ -59,6 +61,21 @@ def configure_logging():
     else:
         # Default to 'warning'
         logging.basicConfig(level=logging.WARNING)
+
+    # Configure the formatter
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logging._defaultFormatter = formatter
+
+    # Add the file handlers for the modules
+    if cfg.has_option('general', 'log_dir'):
+        log_dir = cfg.get('general', 'log_dir')
+
+        # API logging
+        api_log_file = os.path.join(log_dir, 'api.log')
+        api_logger = logging.getLogger('haas.rest')
+        api_logger.addHandler(logging.handlers.TimedRotatingFileHandler(
+                api_log_file, when='D', interval=1))
 
 
 def load_extensions():

--- a/haas/ext/auth/database.py
+++ b/haas/ext/auth/database.py
@@ -137,6 +137,12 @@ class DatabaseAuthBackend(auth.AuthBackend):
         else:
             return False
 
+    def get_user(self):
+        if hasattr(local, 'auth') and local.auth:
+            return local.auth.label
+        else:
+            return None
+
     def _have_admin(self):
         user = local.auth
         return user is not None and user.is_admin

--- a/haas/ext/auth/mock.py
+++ b/haas/ext/auth/mock.py
@@ -29,8 +29,12 @@ class MockAuthBackend(auth.AuthBackend):
         rest.local.auth = {
             'project': None,
             'admin': False,
+            'user': 'user',
         }
         return self._auth_success
+
+    def get_user(self):
+        return rest.local.auth['user']
 
     def set_auth_success(self, ok):
         """Set the return value for `authenticate` to `ok`."""
@@ -48,6 +52,9 @@ class MockAuthBackend(auth.AuthBackend):
 
     def set_admin(self, admin):
         rest.local.auth['admin'] = admin
+
+    def set_user(self, user):
+        rest.local.auth['user'] = user
 
 
 def setup(*args, **kwargs):

--- a/haas/ext/auth/null.py
+++ b/haas/ext/auth/null.py
@@ -10,6 +10,9 @@ class NullAuthBackend(auth.AuthBackend):
     def authenticate(self):
         return True
 
+    def get_user(self):
+        return None
+
     def _have_admin(self):
         return True
 

--- a/haas/rest.py
+++ b/haas/rest.py
@@ -209,9 +209,12 @@ def _rest_wrapper(f, schema):
 
     def wrapper(**kwargs):
         kwargs = _do_validation(schema, kwargs)
-        logger.debug('Got api call: %s(%s)' %
-                     (f.__name__, _format_arglist(**kwargs)))
+
         init_auth()
+        username = auth.get_auth_backend().get_user() or '(guest)'
+        logger.info('%s - API call: %s(%s)' %
+                    (username, f.__name__, _format_arglist(**kwargs)))
+
         ret = f(**kwargs)
         if ret is None:
             ret = ''


### PR DESCRIPTION
Added basic API logging. New configuration option is read from
haas.cfg with the 'log_dir' of the logs.

```
2016-03-31 14:55:07,961 - haas.rest - INFO - (guest) - API call: list_projects()
```