### PR TITLE
Fix arg validation when passing arguments in the URL + body

### DIFF
--- a/docs/developer-guidelines.md
+++ b/docs/developer-guidelines.md
@@ -27,12 +27,21 @@ If you're looking to code, there are a few ways to help:
 * IRL (In Real Life): The MOC group office is on the BU campus, at 3 Cummington Mall, Boston, MA room 451. Anyone interested in HaaS is welcome to drop in and work there.
 * Email: HaaS developers or anyone else wishing to stay up to date should subscribe to haas-dev-list@bu.edu by sending a plain text email to majordomo@bu.edu with "subscribe haas-dev-list" in the body.
 
-# Coding style
+# Coding styles/conventions
 
 By default, HaaS (like many other python projects) uses
 [PEP8](https://www.python.org/dev/peps/pep-0008/) as its naming guide, and
 [PEP257](https://www.python.org/dev/peps/pep-0257/) for documentation.
 Departures are acceptable when called for, but should be discussed first.
+
+## REST API calls
+
+Arguments passed to externally-visible API calls are verified by a combination
+of the Flask API and
+
+### Body-args (Schema)
+
+
 
 ## Often-used code
 In certain cases, one will encounter heavily repeated code that gets run once per API call such as this:

--- a/haas/rest.py
+++ b/haas/rest.py
@@ -177,8 +177,8 @@ def _do_validation(schema, kwargs):
     body = flask.request.get_json(force=True)
 
     validation_error = ValidationError(
-        "The request body %r is not valid for "
-        "this request." % body)
+        "The request body is not valid for this request.")
+
     if not _validates(body):
         # It would be nice to return a more helpful error message
         # here, but it's a little awkward to extract one from the

--- a/haas/rest.py
+++ b/haas/rest.py
@@ -179,11 +179,7 @@ def _do_validation(schema, kwargs):
     validation_error = ValidationError(
         "The request body %r is not valid for "
         "this request." % body)
-    for k in body.keys():
-        if k in kwargs:
-            raise validation_error  # Duplicate key in body + url
-        kwargs[k] = body[k]
-    if not _validates(kwargs):
+    if not _validates(body):
         # It would be nice to return a more helpful error message
         # here, but it's a little awkward to extract one from the
         # schema library. You can easily get something like:
@@ -193,6 +189,10 @@ def _do_validation(schema, kwargs):
         # which, while fairly clear and helpful, is obviously
         # talking about python types, which is gross.
         raise validation_error
+    for k in body.keys():
+        if k in kwargs:
+            raise validation_error  # Duplicate key in body + url
+        kwargs[k] = body[k]
     return kwargs
 
 

--- a/tests/unit/rest.py
+++ b/tests/unit/rest.py
@@ -235,7 +235,9 @@ class TestValidationError(HttpTest):
         def api_call(foo, bar):
             pass
 
-        @rest.rest_call('PUT', '/mixed/args/<arg1>')
+        @rest.rest_call('PUT', '/mixed/args/<arg1>', schema=Schema({
+            "arg2": basestring,
+        }))
         def mixed_args(arg1, arg2):
             return json.dumps([arg1, arg2])
 
@@ -287,6 +289,10 @@ class TestValidationError(HttpTest):
         assert _is_error(self.client.put('/custom-schema', data=json.dumps({
             'the_value': 'Not an integer!',
         })), rest.ValidationError)
+        resp = self.client.put('/custom-schema',
+                               data=json.dumps({'the_value': 2}))
+        assert resp.status_code == 200
+        assert json.loads(resp.get_data()) == 2
 
 
 class TestCallOnce(HttpTest):

--- a/tests/unit/rest.py
+++ b/tests/unit/rest.py
@@ -226,7 +226,12 @@ class TestNoneReturnValue(HttpTest):
 
 
 class TestValidationError(HttpTest):
-    """basic tests for input validation."""
+    """basic tests for input validation.
+    We have three cases we want to validate here:
+        1. No arguments in the URL or body (api_call)
+        2. Argument in the URL and not in the body (url_args)
+        3. Arguments in both the URL and body (mixed_args)
+    """
 
     def setUp(self):
         HttpTest.setUp(self)
@@ -235,17 +240,16 @@ class TestValidationError(HttpTest):
         def api_call(foo, bar):
             pass
 
+        @rest.rest_call('PUT', '/just_url/args/<int:int_arg>/<str_arg>')
+        def url_args(int_arg, str_arg):
+            return json.dumps([int_arg, str_arg])
+
         @rest.rest_call('PUT', '/mixed/args/<arg1>', schema=Schema({
             "arg2": basestring,
         }))
         def mixed_args(arg1, arg2):
             return json.dumps([arg1, arg2])
 
-        @rest.rest_call('PUT', '/custom-schema', schema=Schema({
-            "the_value": int,
-        }))
-        def custom_schema(the_value):
-            return repr(the_value)
 
     def _do_request(self, data):
         """Make a request to the endpoint with `data` in the body.


### PR DESCRIPTION
We were checking both URL arguments & body arguments against the `Schema`, which only verifies body arguments.

Also address a log injection problem, where unsanitized user data was being used directly to raise an exception back to the original user.