### PR TITLE
Updates to migration documentation

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -96,8 +96,34 @@ To generate a new migration script, execute:
 Where `${branch_name}` is either the name of the extension's module (if the
 script is for an extension) or `haas` (if the script is for HaaS core).
 
-Alembic will generate a migration script in the appropriate directory. Again,
-sanity check the output; Alembic's guesses should not be trusted blindly.
+Alembic will look at the differences between the schema in the database and
+the one derived from the HaaS source, and generate its best attempt at a
+migration script. The script will be stored in `haas/migrations/versions`.
+
+The value of `down_revision` should be the identifier of the previous migration script.
+The value of `branch_labels` should be `('<branch_name>',)` where `branch_name` should match what was used in the command to generate the migration script.
+
+Sanity check the output; Alembic often does a good job generating scripts, but
+it should not be trusted blindly.
+
+## Notes on Generating Migrations and Checking the Output
+
+### State of the Database
+
+The database being loaded to generate the migration should match the schema of the cuttent master branch.
+To ensure this, create a new PostgreSQL database and initialise it using `haas-admin db create` while on a branch that is up to date with current HaaS master branch. The command to generate the migration script should then be run after checking out the branch that has the changes that the script shuld be generated for.
+
+### Renaming Columns
+
+Alembic will not rename a column, instead it will delete the original column and create a new one with the new name. This is an issue as the data will then not be contained in the new column (see Data Migration vs Schema Migration below). To change the name of a column the script should be edited manually to remove the lines dropping the old column and creating one with the new name and replace them with a line altering the column: `op.alter_column(u'<table_name>', '<old_column_name>', new_column_name='<new_column_name>')`
+
+### [Data Migration][8] vs. Schema Migration
+
+The migrations Alembic generates are schema migrations: they will create/delete tables, columns, and relationships, but they do not populate these with data. This can be an issue, particularly in the case of a new relationship that would apply to existing data. None of the existing data will be accessible via the new relationship unless the data itself is specifically migrated as well. 
+
+This can be done by directly encoding data within the script and using a command like `bulk_insert()`, executing a SQL statement to SELECT the data and INSERT it into the new column, or by creating a live interaction with the database. 
+
+lines 28-32 in ``89630e3872ec_network_acl.py`` show an example of executing a SQL statement and then using `bulk_insert()` to migrate data
 
 ## Writing tests
 
@@ -143,3 +169,4 @@ the file manually, doing the following:
 [5]: http://alembic.readthedocs.org/en/latest/
 [6]: http://flask-script.readthedocs.org/en/latest/
 [7]: http://alembic.readthedocs.org/en/latest/branches.html
+[8]: https://groups.google.com/forum/#!topic/sqlalchemy-alembic/gCJO4W0GKB4

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -101,7 +101,8 @@ the one derived from the HaaS source, and generate its best attempt at a
 migration script. The script will be stored in `haas/migrations/versions`.
 
 The value of `down_revision` should be the identifier of the previous migration script.
-The value of `branch_labels` should be `('<branch_name>',)` where `branch_name` should match what was used in the command to generate the migration script.
+The value of `branch_labels` should be `('<branch_name>',)` where `branch_name` 
+should match what was used in the command to generate the migration script.
 
 Sanity check the output; Alembic often does a good job generating scripts, but
 it should not be trusted blindly.
@@ -110,20 +111,36 @@ it should not be trusted blindly.
 
 ### State of the Database
 
-The database being loaded to generate the migration should match the schema of the cuttent master branch.
-To ensure this, create a new PostgreSQL database and initialise it using `haas-admin db create` while on a branch that is up to date with current HaaS master branch. The command to generate the migration script should then be run after checking out the branch that has the changes that the script shuld be generated for.
+For automatic migrations the database being loaded to generate the migration should 
+match the schema of the current master branch.
+To ensure this, create a new PostgreSQL database and initialise it using 
+`haas-admin db create` while on a branch that is up to date with current HaaS 
+master branch. The command to generate the migration script should then be run 
+after checking out the branch that has the changes that the script should be generated for.
 
 ### Renaming Columns
 
-Alembic will not rename a column, instead it will delete the original column and create a new one with the new name. This is an issue as the data will then not be contained in the new column (see Data Migration vs Schema Migration below). To change the name of a column the script should be edited manually to remove the lines dropping the old column and creating one with the new name and replace them with a line altering the column: `op.alter_column(u'<table_name>', '<old_column_name>', new_column_name='<new_column_name>')`
+Alembic will not rename a column, instead it will delete the original column 
+and create a new one with the new name. This is an issue as the data will then 
+not be contained in the new column (see Data Migration vs Schema Migration below). 
+To change the name of a column the script should be edited manually to remove the 
+lines dropping the old column and creating one with the new name and replace them 
+with a line altering the column: `op.alter_column(u'<table_name>', '<old_column_name>', new_column_name='<new_column_name>')`
 
 ### [Data Migration][8] vs. Schema Migration
 
-The migrations Alembic generates are schema migrations: they will create/delete tables, columns, and relationships, but they do not populate these with data. This can be an issue, particularly in the case of a new relationship that would apply to existing data. None of the existing data will be accessible via the new relationship unless the data itself is specifically migrated as well. 
+The migrations Alembic generates are schema migrations: they will create/delete tables, 
+columns, and relationships, but they do not populate these with data. This can be an issue, 
+particularly in the case of a new relationship that would apply to existing data. None of 
+the existing data will be accessible via the new relationship unless the data itself is 
+specifically migrated as well. 
 
-This can be done by directly encoding data within the script and using a command like `bulk_insert()`, executing a SQL statement to SELECT the data and INSERT it into the new column, or by creating a live interaction with the database. 
+This can be done by directly encoding data within the script and using a command like 
+`bulk_insert()`, executing a SQL statement to SELECT the data and INSERT it into the new 
+column, or by creating a live interaction with the database. 
 
-lines 28-32 in ``89630e3872ec_network_acl.py`` show an example of executing a SQL statement and then using `bulk_insert()` to migrate data
+lines 28-32 in ``haas/migrations/versions/89630e3872ec_network_acl.py`` show an example
+of executing a SQL statement then using `bulk_insert()` to migrate data.
 
 ## Writing tests
 


### PR DESCRIPTION
@zenhack and @henn 

Here's some updates to the migration docs reflecting the troublesome bits from network ACL.

Do we want specifics on how branching works?

We might want some more detail on generating the new database - particularly where the migration script loads it from so developers can create a new db under a different name if they don't want to scrap their current one.

Also, more info on data vs. schema migrations might be helpful.

addresses #589 