### PR TITLE
Add mock OBM driver as well as null network allocator to default dev config

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -45,8 +45,8 @@ Configuring HaaS
 
 Now the ``haas`` executable should be in your path.  First, create a
 configuration file ``haas.cfg``. There are two examples for you to work from,
-``examples/haas.cfg.dev-example``, which is oriented towards development, and
-``examples/haas.cfg.example`` which is more production oriented.  These config
+``examples/haas.cfg.dev-no-hardware``, which is oriented towards development, and
+``examples/haas.cfg`` which is more production oriented.  These config
 files are well commented; read them carefully.
 
 HaaS can be configured to not perform state-changing operations on nodes,

--- a/examples/haas.cfg.dev-no-hardware
+++ b/examples/haas.cfg.dev-no-hardware
@@ -25,13 +25,16 @@ dry_run=True
 
 [extensions]
 haas.ext.switches.mock =
+haas.ext.obm.mock =
 haas.ext.auth.null =
 
-# haas.ext.network_allocators.null =
-#
+haas.ext.network_allocators.null =
+
 # Depending on what you're trying to do, you may want to use the vlan_pool
 # network allocator instead of the null allocator. To do this, comment out the
 # null allocator extension above, and uncomment the following:
 #
+# haas.ext.network_allocators.vlan_pool =
+# 
 # [haas.ext.network_allocators.vlan_pool]
 # vlans = 100-200, 300-500


### PR DESCRIPTION
This way, most devs without real hardware should be able to just grab the
config and run without adjustments.