### PR TITLE
Disable native-vlan tagging on the Brocade driver

### DIFF
--- a/haas/ext/switches/brocade.py
+++ b/haas/ext/switches/brocade.py
@@ -214,6 +214,7 @@ class Brocade(Switch):
             vlan: vlan to set as the native vlan
         """
         self._set_mode(interface, 'trunk')
+        self._disable_native_tag(interface)
         url = self._construct_url(interface, suffix='trunk')
         payload = '<trunk><native-vlan>%s</native-vlan></trunk>' % vlan
         requests.put(url, data=payload, auth=self._auth)
@@ -226,6 +227,17 @@ class Brocade(Switch):
         """
         url = self._construct_url(interface, suffix='trunk/native-vlan')
         requests.delete(url, auth=self._auth)
+
+    def _disable_native_tag(self, interface):
+        """ Disable tagging of the native vlan
+
+        Args:
+            interface: interface to disable the native vlan tagging of
+
+        """
+        url = self._construct_url(interface, suffix='trunk/tag/native-vlan')
+        response = requests.delete(url, auth=self._auth)
+
 
     def _construct_url(self, interface, suffix=None):
         """ Construct the API url for a specific interface appending suffix.

--- a/tests/unit/ext/switches/brocade.py
+++ b/tests/unit/ext/switches/brocade.py
@@ -206,15 +206,17 @@ class TestBrocade(object):
         with requests_mock.mock() as mock:
             url_mode = switch._construct_url(INTERFACE1, suffix='mode')
             mock.put(url_mode)
+            url_tag = switch._construct_url(INTERFACE1, suffix='trunk/tag/native-vlan')
+            mock.delete(url_tag)
             url_trunk = switch._construct_url(INTERFACE1, suffix='trunk')
             mock.put(url_trunk)
 
             switch.apply_networking(action_native)
 
             assert mock.called
-            assert mock.call_count == 2
+            assert mock.call_count == 3
             assert mock.request_history[0].text == TRUNK_PAYLOAD
-            assert mock.request_history[1].text == TRUNK_NATIVE_PAYLOAD
+            assert mock.request_history[2].text == TRUNK_NATIVE_PAYLOAD
 
         # Test action to remove a native network
         action_rm_native = model.NetworkingAction(nic=nic,


### PR DESCRIPTION
When a native-vlan is added to a port, disable native-vlan tagging.
This should be equivalent to running:

no switchport trunk tag native-vlan